### PR TITLE
:wrench: Fix swagger documentation for crawling all routes list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -925,9 +925,9 @@
       "dev": true
     },
     "@types/swagger-schema-official": {
-      "version": "2.0.20",
-      "resolved": "https://registry.npmjs.org/@types/swagger-schema-official/-/swagger-schema-official-2.0.20.tgz",
-      "integrity": "sha512-GHdvwZQg7i+6AUMnP+tqYJJbt59SuYu8k9dzX8E6TJ5QFXKW9FxfdfqT5g+VcyuEua+/YaRzumqJ6wcQMuSP5Q=="
+      "version": "2.0.21",
+      "resolved": "https://registry.npmjs.org/@types/swagger-schema-official/-/swagger-schema-official-2.0.21.tgz",
+      "integrity": "sha512-n9BbLOjR4Hre7B4TSGGMPohOgOg8tcp00uxqsIE00uuWQC0QuX57G1bqC1csLsk2DpTGtHkd0dEb3ipsCZ9dAA=="
     },
     "@types/tmp": {
       "version": "0.1.0",
@@ -2869,11 +2869,11 @@
       }
     },
     "fastify-plugin": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-1.6.0.tgz",
-      "integrity": "sha512-lFa9txg8LZx4tljj33oG53nUXhVg0baZxtP9Pxi0dJmI0NQxzkDk5DS9kr3D7iMalUAp3mvIq16OQumc7eIvLA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-1.6.1.tgz",
+      "integrity": "sha512-APBcb27s+MjaBIerFirYmBLatoPCgmHZM6XP0K+nDL9k0yX8NJPWDY1RAC3bh6z+AB5ULS2j31BUfLMT3uaZ4A==",
       "requires": {
-        "semver": "^6.0.0"
+        "semver": "^6.3.0"
       },
       "dependencies": {
         "semver": {
@@ -2884,9 +2884,9 @@
       }
     },
     "fastify-static": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/fastify-static/-/fastify-static-2.6.0.tgz",
-      "integrity": "sha512-OyaGl6KWQQCdv8FO9w0BAc1NYohuJizQkEGqBGaUijDmluIgU1YJr088inSyo2nVd688At50KiZKmeVKYHWYgw==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/fastify-static/-/fastify-static-2.7.0.tgz",
+      "integrity": "sha512-B+Ox0jL42OwGOzn01RTt+cPaIyCLsHURse1o6t+0tqiuTBlXUC7RkR+siuJ4/PSiRpy0cu5DA0Giu5d+gtXyjA==",
       "requires": {
         "fastify-plugin": "^1.6.0",
         "glob": "^7.1.4",
@@ -2895,9 +2895,9 @@
       }
     },
     "fastify-swagger": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/fastify-swagger/-/fastify-swagger-2.5.0.tgz",
-      "integrity": "sha512-WF3LpwwZunLtxzs1Dukwg7P4uBR9f2cwXL/JKD5D4O9Leq/S2QUfMNZg0eHxe4bJy1aUS9tt7IAHvY3ybgbApg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/fastify-swagger/-/fastify-swagger-2.6.0.tgz",
+      "integrity": "sha512-aavYxyaS+/s4Xk3rAAfWRjAYdbR4WmK0NU3n4KPRFTu7ucF8Nc4ofWVoLS4yML1qlbRr/c31mR32VGpzIm8DKA==",
       "requires": {
         "@types/swagger-schema-official": "^2.0.20",
         "fastify-plugin": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "eslint-config-prettier": "^6.10.0",
         "eslint-plugin-prettier": "^3.1.2",
         "fastify": "^2.15.1",
-        "fastify-swagger": "^2.5.0",
+        "fastify-swagger": "^2.6.0",
         "mongodb-memory-server": "^6.2.4",
         "mongoose": "^5.8.12"
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,12 +9,12 @@ const env = process.env.NODE_ENV;
 // Configure HTTP server
 const app = fastify.default({ logger: true });
 
+// Register Swagger
+app.register(swagger, Options);
+
 routes.forEach(route => {
 	app.route(route);
 });
-
-// Register Swagger
-app.register(swagger, Options);
 
 const start = async (): Promise<void> => {
 	try {


### PR DESCRIPTION
After doing some research at fastify-swagger and as stated in the [📘 usage documentation](https://github.com/fastify/fastify-swagger#usage) that route need defined after register the swagger. So that, I add this PR to fix this issue: [issue#5](https://github.com/gmarokov/node-fastify-mongo-api/issues/5) :wrench:

Again, thank you for this great starter template.